### PR TITLE
update README [show option]

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ Options are specified on the [`with` map](https://docs.github.com/en/actions/usi
 
   This file is [GitHub Flavored Markdown (GFM)](https://github.github.com/gfm/) and may include permitted HTML.
 
+* **`show`: which tests have to be shown in the summary** (optional, by default just the failed tests are shown in the summary)
+
+  - To show all tests, specify: `show: "all"`. For example:
+
+    ```yaml
+    - uses: test-summary/action@v1
+      with:
+        show: "all"
+    ```
+
+  - To show no tests, specify: `show: "none"`
+
+
 FAQ
 ---
 * **How is the summary graphic generated? Does any of my data ever leave GitHub?**  


### PR DESCRIPTION
Hi @ethomson.
I'm Dario, a developer at [BuildNN](https://github.com/buildnn/).
Firstly, I want to thank you for the great work you did, I use your action basically everyday and It works really great.

Developing my [pytest-summary](https://github.com/dariocurr/pytest-summary) extension I discovered about the option `show` that is not mentioned on the `README`.
Since I consider it helpful, I added it.

PS. any advice on my extension is more than welcome