### PR TITLE
Switch to using NodeJS v16 as a action runtime

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,9 @@ jobs:
       - name: Check out source
         uses: actions/checkout@v3
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '16'
       - name: Build
         run: |
           npm ci
@@ -54,9 +54,9 @@ jobs:
           ref: 'dist'
           path: 'dist'
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: '12'
+          node-version: '16'
       - name: Build
         run: |
           npm ci

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   show:
     description: Types of tests to show in the results table
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'index.js'
 branding:
   icon: check-square


### PR DESCRIPTION
NodeJS v12 is EOL and it's been deprecated since April 2022. It will stop being available in GitHub Actions CI/CD workflows by the summer
2023. But it already triggers deprecation warnings that show up on the workflow summary page:
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

This patch fixes that.

Resolves #15