### PR TITLE
Check for key existence to identify junit file

### DIFF
--- a/src/test_parser.ts
+++ b/src/test_parser.ts
@@ -312,7 +312,7 @@ export async function parseFile(filename: string): Promise<TestResult> {
 
     const xml: any = await parser(data)
 
-    if (xml.testsuites || xml.testsuite) {
+    if ('testsuites' in xml || 'testsuite' in xml) {
         return await parseJunitXml(xml)
     }
 

--- a/test/file.ts
+++ b/test/file.ts
@@ -55,4 +55,11 @@ describe("file", async () => {
         expect(result.counts.failed).to.eql(4)
         expect(result.counts.skipped).to.eql(2)
     })
+
+    it("identifies empty junit", async () => {
+        const result = await parseFile(`${junitResourcePath}/05-empty.xml`)
+        expect(result.counts.passed).to.eql(0)
+        expect(result.counts.failed).to.eql(0)
+        expect(result.counts.skipped).to.eql(0)
+    })
 })


### PR DESCRIPTION
Given the empty test files, it seems like the intention was for this to work. The falsy checks on `testsuites` caused a file with `<testsuites />` to fail the junit identity check because the value of `testsuites` was `''`