### PR TITLE
add `folded` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ Options are specified on the [`with` map](https://docs.github.com/en/actions/usi
       show: "fail, skip"
   ```
 
+* **`folded`: display test details in a folded details block** (optional)
+  When enabled the details for each test result will be nested in a details blocks which can be expanded by clicking on the test name. This option can be `true` or `false` (The default).
+
+  ```yaml
+  - uses: test-summary/action@v2
+    with:
+      paths: "test/results/**/TEST-*.xml"
+      folded: true
+  ```
+
 FAQ
 ---
 * **How is the summary graphic generated? Does any of my data ever leave GitHub?**  

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,8 @@ inputs:
     description: File to write with rendered output
   show:
     description: Types of tests to show in the results table
+  folded:
+    description: Show each result in a folded details block
 runs:
   using: 'node20'
   main: 'index.js'

--- a/src/dashboard.ts
+++ b/src/dashboard.ts
@@ -28,7 +28,7 @@ export function dashboardSummary(result: TestResult): string {
     return `<img src="${dashboardUrl}?p=${count.passed}&f=${count.failed}&s=${count.skipped}" alt="${summary}">`
 }
 
-export function dashboardResults(result: TestResult, show: number): string {
+export function dashboardResults(result: TestResult, show: number, folded: boolean): string {
     let table = "<table>"
     let count = 0
 
@@ -41,6 +41,9 @@ export function dashboardResults(result: TestResult, show: number): string {
             }
 
             table += "<tr><td>"
+            if (folded) {
+                table += "<details><summary>"
+            }
 
             const icon = statusIcon(testcase.status)
             if (icon) {
@@ -53,6 +56,10 @@ export function dashboardResults(result: TestResult, show: number): string {
             if (testcase.description) {
                 table += ": "
                 table += escapeHTML(testcase.description)
+            }
+
+            if (folded) {
+                table += "</summary>"
             }
 
             if (testcase.message || testcase.details) {
@@ -69,6 +76,10 @@ export function dashboardResults(result: TestResult, show: number): string {
                     table += escapeHTML(testcase.details)
                     table += "</code></pre>"
                 }
+            }
+
+            if (folded) {
+                table += "</details>"
             }
 
             table += "</td></tr>\n"

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ async function run(): Promise<void> {
         const pathGlobs = core.getInput("paths", { required: true })
         const outputFile = core.getInput("output") || process.env.GITHUB_STEP_SUMMARY || "-"
         const showList = core.getInput("show")
+	const folded = JSON.parse(core.getInput("folded") || "false")
 
         /*
          * Given paths may either be an individual path (eg "foo.xml"),
@@ -99,7 +100,7 @@ async function run(): Promise<void> {
         let output = dashboardSummary(total)
 
         if (show) {
-            output += dashboardResults(total, show)
+            output += dashboardResults(total, show, folded)
         }
 
         if (outputFile === "-") {

--- a/test/dashboard.ts
+++ b/test/dashboard.ts
@@ -29,7 +29,7 @@ describe("dashboard", async () => {
                 }
             ]
         }
-        const actual = dashboardResults(result, TestStatus.Fail)
+        const actual = dashboardResults(result, TestStatus.Fail, false)
         expect(actual).contains("name escaped &lt;properly&gt;")
         expect(actual).contains("description escaped &quot;properly&quot;")
         expect(actual).contains("another name escaped &apos;properly&apos;")
@@ -51,7 +51,7 @@ describe("dashboard", async () => {
                 }
             ]
         }
-        const actual = dashboardResults(result, TestStatus.Fail)
+        const actual = dashboardResults(result, TestStatus.Fail, false)
         expect(actual).contains("&lt;no name&gt;")
     })
 
@@ -72,7 +72,7 @@ describe("dashboard", async () => {
             ]
         }
 
-        const actual = dashboardResults(result, TestStatus.Fail)
+        const actual = dashboardResults(result, TestStatus.Fail, false)
 
         expect(actual).contains("message escaped &lt;properly&gt;")
         expect(actual).contains("details escaped &lt;properly&gt;")


### PR DESCRIPTION
Thanks for the useful action!

For our test runs we sometimes have several test failure with large tracebacks. It's helpful to get an overview of the failures by scanning the test names, then look into the details of the failures.

This PR adds a `folded` option which puts the tracebacks in a `<details>` block. So for a failing test the html will look something like:
```html
<tr><td><details><summary><img...>test name</summary><br><pre><code>...
```
Here's a screenshot from an example test run:
<img width="779" alt="Screenshot 2024-08-07 at 9 45 10 AM" src="https://github.com/user-attachments/assets/ab0bb4cb-b3d8-4330-8d11-7fb789118e13">

and one with the first test expanded:
<img width="631" alt="Screenshot 2024-08-07 at 9 45 52 AM" src="https://github.com/user-attachments/assets/1470322b-7588-4f0d-a26a-9000d34750cd">

Please excuse any silly mistakes and any comments suggestions are greatly appreciated. It's the first few lines of typescript I've ever written.

By default the option is off but can be enabled by providing `folded: true` in the action configuration.
