### PR TITLE
Parse attributeless <failure> tags correctly

### DIFF
--- a/src/test_parser.ts
+++ b/src/test_parser.ts
@@ -250,7 +250,11 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
                 const element = failure_or_error[0]
 
                 message = element.$ ? element.$.message : undefined
-                details = element._
+                if (typeof element === "string") {
+                    details = element
+                } else {
+                    details = element._
+                }
 
                 counts.failed++
             } else {

--- a/test/junit.ts
+++ b/test/junit.ts
@@ -150,4 +150,12 @@ describe("junit", async () => {
     it("parses testsuite with no failure message", async () => {
         const result = await parseJunitFile(`${resourcePath}/07-no-failure-message.xml`)
     })
+
+    it("parses attributeless failure tags", async () => {
+        // https://github.com/jest-community/jest-junit generates failure tags
+        // that have no attributes, only inner text.
+        // Example: <failure>Failed!</failure>
+        const result = await parseJunitFile(`${resourcePath}/08-failure-noattr-only-innertext.xml`)
+        expect(result.suites[0].cases[0].details).to.eql("Failed!")
+    })
 })

--- a/test/resources/junit/08-failure-noattr-only-innertext.xml
+++ b/test/resources/junit/08-failure-noattr-only-innertext.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="jest tests">
+    <testsuite name="testsuite1">
+        <testcase id="com.example.test1" name="Test 1" time="0.001">
+            <failure>Failed!</failure>
+        </testcase>
+    </testsuite>
+</testsuites>


### PR DESCRIPTION
[`jest-junit`](https://github.com/jest-community/jest-junit) generates failure tags that have no attributes, only inner text. For example: `<failure>Failed!</failure>`.

The [`xml2js`](https://www.npmjs.com/package/xml2js) library seems to produce different objects based on whether a tag has attributes. See the minimal example:
```js
var parseString = require('xml2js').parseString;
var print = (err, result) => console.log(JSON.stringify(result, null, 2))
var parse = (xmlStr) => parseString(xmlStr, print)

parse('<a b="c">d</a>')
{
  "a": {
    "_": "d",
    "$": {
      "b": "c"
    }
  }
}

parse('<a>d</a>')
{
  "a": "d"
}
```

Notice how the second output above is not `{"a": {"_": "d"}}`

With this change, we take into account this difference while parsing the failure messages.