### PR TITLE
feat: bump node version on actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Build
         run: |
           npm ci
@@ -32,7 +32,7 @@ jobs:
           paths: test/results/*.xml
           output: test/results/results.html
       - name: Upload test summary
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-summary
           path: test/results/results.html
@@ -47,16 +47,16 @@ jobs:
 
     steps:
       - name: Check out source
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
       - name: Check out distribution branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: 'dist'
           path: 'dist'
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
       - name: Build
         run: |
           npm ci

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
   show:
     description: Types of tests to show in the results table
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'index.js'
 branding:
   icon: check-square

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/chai": "^4.3.4",
         "@types/chai-as-promised": "^7.1.5",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^18.11.18",
+        "@types/node": "^24.0.0",
         "@types/xml2js": "^0.4.11",
         "@vercel/ncc": "^0.36.0",
         "chai": "^4.3.7",
@@ -32,7 +32,7 @@
         "mocha-multi-reporters": "^1.5.1",
         "prettier": "^2.8.3",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.4"
+        "typescript": "^5.8.0"
       }
     },
     "node_modules/@actions/core": {
@@ -1491,9 +1491,13 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/prettier": {
       "version": "2.7.2",
@@ -6757,16 +6761,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {
@@ -6783,6 +6788,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.10",
@@ -8276,9 +8287,12 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.11.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.18.tgz",
-      "integrity": "sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA=="
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
+      "requires": {
+        "undici-types": "~7.16.0"
+      }
     },
     "@types/prettier": {
       "version": "2.7.2",
@@ -12113,9 +12127,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true
     },
     "unbox-primitive": {
@@ -12129,6 +12143,11 @@
         "has-symbols": "^1.0.3",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="
     },
     "update-browserslist-db": {
       "version": "1.0.10",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^18.11.18",
+    "@types/node": "^24.0.0",
     "@types/xml2js": "^0.4.11",
     "@vercel/ncc": "^0.36.0",
     "chai": "^4.3.7",
@@ -52,6 +52,6 @@
     "mocha-multi-reporters": "^1.5.1",
     "prettier": "^2.8.3",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.4"
+    "typescript": "^5.8.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import { dashboardResults, dashboardSummary } from "./dashboard"
 async function run(): Promise<void> {
     try {
         const pathGlobs = core.getInput("paths", { required: true })
-        const outputFile = core.getInput("output") || process.env.GITHUB_STEP_SUMMARY || "-"
+        const outputFile =
+            core.getInput("output") || process.env.GITHUB_STEP_SUMMARY || "-"
         const showList = core.getInput("show")
 
         /*
@@ -17,11 +18,11 @@ async function run(): Promise<void> {
          * a path glob (eg "**TEST-*.xml"), or may be newline separated
          * (from a multi-line yaml scalar).
          */
-        const paths = [ ]
+        const paths = []
 
         for (const path of pathGlobs.split(/\r?\n/)) {
             if (glob.hasMagic(path)) {
-                paths.push(...await glob.promise(path))
+                paths.push(...(await glob.promise(path)))
             } else {
                 paths.push(path.trim())
             }
@@ -29,7 +30,7 @@ async function run(): Promise<void> {
 
         let show = TestStatus.Fail
         if (showList) {
-            show = 0
+            show = TestStatus.None
 
             for (const showName of showList.split(/,\s*/)) {
                 if (showName === "none") {
@@ -39,7 +40,12 @@ async function run(): Promise<void> {
                     continue
                 }
 
-                const showValue = (TestStatus as any)[showName.replace(/^([a-z])(.*)/, (m, p1, p2) => p1.toUpperCase() + p2)]
+                const showValue = (TestStatus as any)[
+                    showName.replace(
+                        /^([a-z])(.*)/,
+                        (m, p1, p2) => p1.toUpperCase() + p2
+                    )
+                ]
 
                 if (!showValue) {
                     throw new Error(`unknown test type: ${showName}`)
@@ -60,10 +66,12 @@ async function run(): Promise<void> {
                 core.debug(`: ${path}`)
             }
 
-            core.debug(`Output file: ${outputFile === '-' ? "(stdout)" : outputFile}`)
+            core.debug(
+                `Output file: ${outputFile === "-" ? "(stdout)" : outputFile}`
+            )
 
             let showInfo = "Tests to show:"
-            if (show === 0) {
+            if (show === TestStatus.None) {
                 showInfo += " none"
             }
             for (const showName in TestStatus) {
@@ -80,7 +88,7 @@ async function run(): Promise<void> {
 
         const total: TestResult = {
             counts: { passed: 0, failed: 0, skipped: 0 },
-            suites: [ ],
+            suites: [],
             exception: undefined
         }
 
@@ -109,10 +117,13 @@ async function run(): Promise<void> {
             await writefile(outputFile, output)
         }
 
-        core.setOutput('passed', total.counts.passed)
-        core.setOutput('failed', total.counts.failed)
-        core.setOutput('skipped', total.counts.skipped)
-        core.setOutput('total', total.counts.passed + total.counts.failed + total.counts.skipped)
+        core.setOutput("passed", total.counts.passed)
+        core.setOutput("failed", total.counts.failed)
+        core.setOutput("skipped", total.counts.skipped)
+        core.setOutput(
+            "total",
+            total.counts.passed + total.counts.failed + total.counts.skipped
+        )
     } catch (error) {
         if (error instanceof Error) {
             core.setFailed(error.message)

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,8 +9,7 @@ import { dashboardResults, dashboardSummary } from "./dashboard"
 async function run(): Promise<void> {
     try {
         const pathGlobs = core.getInput("paths", { required: true })
-        const outputFile =
-            core.getInput("output") || process.env.GITHUB_STEP_SUMMARY || "-"
+        const outputFile = core.getInput("output") || process.env.GITHUB_STEP_SUMMARY || "-"
         const showList = core.getInput("show")
 
         /*
@@ -40,12 +39,7 @@ async function run(): Promise<void> {
                     continue
                 }
 
-                const showValue = (TestStatus as any)[
-                    showName.replace(
-                        /^([a-z])(.*)/,
-                        (m, p1, p2) => p1.toUpperCase() + p2
-                    )
-                ]
+                const showValue = (TestStatus as any)[showName.replace(/^([a-z])(.*)/, (m, p1, p2) => p1.toUpperCase() + p2)]
 
                 if (!showValue) {
                     throw new Error(`unknown test type: ${showName}`)
@@ -66,9 +60,7 @@ async function run(): Promise<void> {
                 core.debug(`: ${path}`)
             }
 
-            core.debug(
-                `Output file: ${outputFile === "-" ? "(stdout)" : outputFile}`
-            )
+            core.debug(`Output file: ${outputFile === "-" ? "(stdout)" : outputFile}`)
 
             let showInfo = "Tests to show:"
             if (show === TestStatus.None) {
@@ -120,10 +112,7 @@ async function run(): Promise<void> {
         core.setOutput("passed", total.counts.passed)
         core.setOutput("failed", total.counts.failed)
         core.setOutput("skipped", total.counts.skipped)
-        core.setOutput(
-            "total",
-            total.counts.passed + total.counts.failed + total.counts.skipped
-        )
+        core.setOutput("total", total.counts.passed + total.counts.failed + total.counts.skipped)
     } catch (error) {
         if (error instanceof Error) {
             core.setFailed(error.message)

--- a/src/test_parser.ts
+++ b/src/test_parser.ts
@@ -5,9 +5,9 @@ import xml2js from "xml2js"
 
 export enum TestStatus {
     None = 0,
-    Pass = 1 << 0,
-    Fail = 1 << 1,
-    Skip = 1 << 2
+    Pass = (1 << 0),
+    Fail = (1 << 1),
+    Skip = (1 << 2)
 }
 
 export interface TestCounts {
@@ -59,10 +59,10 @@ export async function parseTap(data: string): Promise<TestResult> {
     let testMax = 0
     let num = 0
 
-    const suites: TestSuite[] = []
+    const suites: TestSuite[] = [ ]
     let exception: string | undefined = undefined
 
-    let cases = []
+    let cases = [ ]
     let suitename: string | undefined = undefined
 
     const counts = {
@@ -80,7 +80,7 @@ export async function parseTap(data: string): Promise<TestResult> {
         let description: string | undefined = undefined
         let details: string | undefined = undefined
 
-        if ((found = line.match(/^\s*#(.*)/))) {
+        if (found = line.match(/^\s*#(.*)/)) {
             if (!found[1]) {
                 continue
             }
@@ -93,54 +93,42 @@ export async function parseTap(data: string): Promise<TestResult> {
                 })
 
                 suitename = undefined
-                cases = []
+                cases = [ ]
             }
 
-            if (suitename) suitename += " " + found[1].trim()
-            else suitename = found[1].trim()
+            if (suitename)
+                suitename += " " + found[1].trim()
+            else
+                suitename = found[1].trim()
             continue
-        } else if (
-            (found = line.match(
-                /^ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Ss][Kk][Ii][Pp]\S*(?:\s+(.*?)\s*)?$/
-            ))
-        ) {
+        } else if (found = line.match(/^ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Ss][Kk][Ii][Pp]\S*(?:\s+(.*?)\s*)?$/)) {
             num = parseInt(found[1])
             status = TestStatus.Skip
-            name = found[2] && found[2].length > 0 ? found[2] : undefined
+            name = (found[2] && found[2].length > 0) ? found[2] : undefined
             description = found[3]
 
             counts.skipped++
-        } else if (
-            (found = line.match(/^ok(?:\s+(\d+))?\s*-?\s*(?:(.*?)\s*)?$/))
-        ) {
+        } else if (found = line.match(/^ok(?:\s+(\d+))?\s*-?\s*(?:(.*?)\s*)?$/)) {
             num = parseInt(found[1])
             status = TestStatus.Pass
             name = found[2]
 
             counts.passed++
-        } else if (
-            (found = line.match(
-                /^not ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Tt][Oo][Dd][Oo](?:\s+(.*?)\s*)?$/
-            ))
-        ) {
+        } else if (found = line.match(/^not ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Tt][Oo][Dd][Oo](?:\s+(.*?)\s*)?$/)) {
             num = parseInt(found[1])
             status = TestStatus.Skip
-            name = found[2] && found[2].length > 0 ? found[2] : undefined
+            name = (found[2] && found[2].length > 0) ? found[2] : undefined
             description = found[3]
 
             counts.skipped++
-        } else if (
-            (found = line.match(
-                /^not ok(?:\s+(\d+))?\s*-?\s*-?\s*(?:(.*?)\s*)?$/
-            ))
-        ) {
+        } else if (found = line.match(/^not ok(?:\s+(\d+))?\s*-?\s*-?\s*(?:(.*?)\s*)?$/)) {
             num = parseInt(found[1])
             status = TestStatus.Fail
             name = found[2]
 
             counts.failed++
         } else if (line.match(/^Bail out\!/)) {
-            const message = line.match(/^Bail out\!(.*)/)
+            const message = (line.match(/^Bail out\!(.*)/))
 
             if (message) {
                 exception = message[1].trim()
@@ -163,18 +151,20 @@ export async function parseTap(data: string): Promise<TestResult> {
             testMax = num
         }
 
-        if (i + 1 < lines.length && lines[i + 1].match(/^  ---$/)) {
+        if ((i + 1) < lines.length && lines[i + 1].match(/^  ---$/)) {
             i++
 
             while (i < lines.length && !lines[i + 1].match(/^  \.\.\.$/)) {
-                const detail = lines[i + 1].match(/^  (.*)/)
+                const detail = (lines[i + 1].match(/^  (.*)/))
 
                 if (!detail) {
                     throw new Error("invalid yaml in test case details")
                 }
 
-                if (details) details += "\n" + detail[1]
-                else details = detail[1]
+                if (details)
+                    details += "\n" + detail[1]
+                else
+                    details = detail[1]
 
                 i++
             }
@@ -213,10 +203,10 @@ export async function parseTap(data: string): Promise<TestResult> {
 async function parseJunitXml(xml: any): Promise<TestResult> {
     let testsuites
 
-    if ("testsuites" in xml) {
-        testsuites = xml.testsuites.testsuite || []
-    } else if ("testsuite" in xml) {
-        testsuites = [xml.testsuite]
+    if ('testsuites' in xml) {
+        testsuites = xml.testsuites.testsuite || [ ]
+    } else if ('testsuite' in xml) {
+        testsuites = [ xml.testsuite ]
     } else {
         throw new Error("expected top-level testsuites or testsuite node")
     }
@@ -225,7 +215,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
         throw new Error("expected array of testsuites")
     }
 
-    const suites: TestSuite[] = []
+    const suites: TestSuite[] = [ ]
     const counts = {
         passed: 0,
         failed: 0,
@@ -233,7 +223,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
     }
 
     for (const testsuite of testsuites) {
-        const cases = []
+        const cases = [ ]
 
         if (!Array.isArray(testsuite.testcase)) {
             continue
@@ -255,9 +245,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
                 status = TestStatus.Skip
 
                 counts.skipped++
-            } else if (
-                (failure_or_error = testcase.failure || testcase.error)
-            ) {
+            } else if (failure_or_error = testcase.failure || testcase.error) {
                 status = TestStatus.Fail
 
                 const element = failure_or_error[0]
@@ -321,11 +309,9 @@ export async function parseFile(filename: string): Promise<TestResult> {
 
     const data = await readfile(filename, "utf8")
 
-    if (
-        data.match(/^TAP version 13\r?\n/) ||
+    if (data.match(/^TAP version 13\r?\n/) ||
         data.match(/^ok /) ||
-        data.match(/^not ok /)
-    ) {
+        data.match(/^not ok /)) {
         return await parseTap(data)
     }
 
@@ -337,3 +323,4 @@ export async function parseFile(filename: string): Promise<TestResult> {
 
     throw new Error(`unknown test file type for '${filename}'`)
 }
+

--- a/src/test_parser.ts
+++ b/src/test_parser.ts
@@ -4,9 +4,10 @@ import * as util from "util"
 import xml2js from "xml2js"
 
 export enum TestStatus {
-    Pass = (1 << 0),
-    Fail = (1 << 1),
-    Skip = (1 << 2)
+    None = 0,
+    Pass = 1 << 0,
+    Fail = 1 << 1,
+    Skip = 1 << 2
 }
 
 export interface TestCounts {
@@ -58,10 +59,10 @@ export async function parseTap(data: string): Promise<TestResult> {
     let testMax = 0
     let num = 0
 
-    const suites: TestSuite[] = [ ]
+    const suites: TestSuite[] = []
     let exception: string | undefined = undefined
 
-    let cases = [ ]
+    let cases = []
     let suitename: string | undefined = undefined
 
     const counts = {
@@ -79,7 +80,7 @@ export async function parseTap(data: string): Promise<TestResult> {
         let description: string | undefined = undefined
         let details: string | undefined = undefined
 
-        if (found = line.match(/^\s*#(.*)/)) {
+        if ((found = line.match(/^\s*#(.*)/))) {
             if (!found[1]) {
                 continue
             }
@@ -92,43 +93,55 @@ export async function parseTap(data: string): Promise<TestResult> {
                 })
 
                 suitename = undefined
-                cases = [ ]
+                cases = []
             }
 
-            if (suitename)
-                suitename += " " + found[1].trim()
-            else
-                suitename = found[1].trim()
+            if (suitename) suitename += " " + found[1].trim()
+            else suitename = found[1].trim()
             continue
-        } else if (found = line.match(/^ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Ss][Kk][Ii][Pp]\S*(?:\s+(.*?)\s*)?$/)) {
+        } else if (
+            (found = line.match(
+                /^ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Ss][Kk][Ii][Pp]\S*(?:\s+(.*?)\s*)?$/
+            ))
+        ) {
             num = parseInt(found[1])
             status = TestStatus.Skip
-            name = (found[2] && found[2].length > 0) ? found[2] : undefined
+            name = found[2] && found[2].length > 0 ? found[2] : undefined
             description = found[3]
 
             counts.skipped++
-        } else if (found = line.match(/^ok(?:\s+(\d+))?\s*-?\s*(?:(.*?)\s*)?$/)) {
+        } else if (
+            (found = line.match(/^ok(?:\s+(\d+))?\s*-?\s*(?:(.*?)\s*)?$/))
+        ) {
             num = parseInt(found[1])
             status = TestStatus.Pass
             name = found[2]
 
             counts.passed++
-        } else if (found = line.match(/^not ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Tt][Oo][Dd][Oo](?:\s+(.*?)\s*)?$/)) {
+        } else if (
+            (found = line.match(
+                /^not ok(?:\s+(\d+))?\s*-?\s*([^#]*?)\s*#\s*[Tt][Oo][Dd][Oo](?:\s+(.*?)\s*)?$/
+            ))
+        ) {
             num = parseInt(found[1])
             status = TestStatus.Skip
-            name = (found[2] && found[2].length > 0) ? found[2] : undefined
+            name = found[2] && found[2].length > 0 ? found[2] : undefined
             description = found[3]
 
             counts.skipped++
-        } else if (found = line.match(/^not ok(?:\s+(\d+))?\s*-?\s*-?\s*(?:(.*?)\s*)?$/)) {
+        } else if (
+            (found = line.match(
+                /^not ok(?:\s+(\d+))?\s*-?\s*-?\s*(?:(.*?)\s*)?$/
+            ))
+        ) {
             num = parseInt(found[1])
             status = TestStatus.Fail
             name = found[2]
 
             counts.failed++
         } else if (line.match(/^Bail out\!/)) {
-            const message = (line.match(/^Bail out\!(.*)/))
-            
+            const message = line.match(/^Bail out\!(.*)/)
+
             if (message) {
                 exception = message[1].trim()
             }
@@ -150,20 +163,18 @@ export async function parseTap(data: string): Promise<TestResult> {
             testMax = num
         }
 
-        if ((i + 1) < lines.length && lines[i + 1].match(/^  ---$/)) {
+        if (i + 1 < lines.length && lines[i + 1].match(/^  ---$/)) {
             i++
 
             while (i < lines.length && !lines[i + 1].match(/^  \.\.\.$/)) {
-                const detail = (lines[i + 1].match(/^  (.*)/))
+                const detail = lines[i + 1].match(/^  (.*)/)
 
                 if (!detail) {
                     throw new Error("invalid yaml in test case details")
                 }
 
-                if (details)
-                    details += "\n" + detail[1]
-                else
-                    details = detail[1]
+                if (details) details += "\n" + detail[1]
+                else details = detail[1]
 
                 i++
             }
@@ -202,10 +213,10 @@ export async function parseTap(data: string): Promise<TestResult> {
 async function parseJunitXml(xml: any): Promise<TestResult> {
     let testsuites
 
-    if ('testsuites' in xml) {
-        testsuites = xml.testsuites.testsuite || [ ]
-    } else if ('testsuite' in xml) {
-        testsuites = [ xml.testsuite ]
+    if ("testsuites" in xml) {
+        testsuites = xml.testsuites.testsuite || []
+    } else if ("testsuite" in xml) {
+        testsuites = [xml.testsuite]
     } else {
         throw new Error("expected top-level testsuites or testsuite node")
     }
@@ -214,7 +225,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
         throw new Error("expected array of testsuites")
     }
 
-    const suites: TestSuite[] = [ ]
+    const suites: TestSuite[] = []
     const counts = {
         passed: 0,
         failed: 0,
@@ -222,7 +233,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
     }
 
     for (const testsuite of testsuites) {
-        const cases = [ ]
+        const cases = []
 
         if (!Array.isArray(testsuite.testcase)) {
             continue
@@ -244,7 +255,9 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
                 status = TestStatus.Skip
 
                 counts.skipped++
-            } else if (failure_or_error = testcase.failure || testcase.error) {
+            } else if (
+                (failure_or_error = testcase.failure || testcase.error)
+            ) {
                 status = TestStatus.Fail
 
                 const element = failure_or_error[0]
@@ -260,7 +273,7 @@ async function parseJunitXml(xml: any): Promise<TestResult> {
             } else {
                 counts.passed++
             }
-            
+
             cases.push({
                 status: status,
                 name: name,
@@ -308,9 +321,11 @@ export async function parseFile(filename: string): Promise<TestResult> {
 
     const data = await readfile(filename, "utf8")
 
-    if (data.match(/^TAP version 13\r?\n/) ||
+    if (
+        data.match(/^TAP version 13\r?\n/) ||
         data.match(/^ok /) ||
-        data.match(/^not ok /)) {
+        data.match(/^not ok /)
+    ) {
         return await parseTap(data)
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "**/*.test.ts"]


### PR DESCRIPTION
Superset of https://github.com/test-summary/action/pull/66 with fewer changes, but overall same goal: bringing this package up to node24 so that we can get rid of Node 20 as it will get deprecated in September 26.Superset of https://github.com/test-summary/action/pull/66 with fewer changes, but overall same goal: bringing this package up to node24 so that we can get rid of Node 20 as it will get deprecated in September 26.